### PR TITLE
bump solana and anchor versions so unit tests work again

### DIFF
--- a/frontend/claim_sdk/idl/token_dispenser.json
+++ b/frontend/claim_sdk/idl/token_dispenser.json
@@ -476,7 +476,7 @@
                 "type": "string"
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -494,7 +494,7 @@
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -515,7 +515,7 @@
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -533,7 +533,7 @@
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -542,7 +542,7 @@
             "name": "Cosmwasm",
             "fields": [
               {
-                "name": "chain_id",
+                "name": "chainId",
                 "type": "string"
               },
               {
@@ -555,7 +555,7 @@
                 }
               },
               {
-                "name": "recovery_id",
+                "name": "recoveryId",
                 "type": "u8"
               },
               {
@@ -586,7 +586,7 @@
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]

--- a/frontend/claim_sdk/idl/token_dispenser.ts
+++ b/frontend/claim_sdk/idl/token_dispenser.ts
@@ -477,7 +477,7 @@ export type TokenDispenser =
                 "type": "string"
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -495,7 +495,7 @@ export type TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -516,7 +516,7 @@ export type TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -534,7 +534,7 @@ export type TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -543,7 +543,7 @@ export type TokenDispenser =
             "name": "Cosmwasm",
             "fields": [
               {
-                "name": "chain_id",
+                "name": "chainId",
                 "type": "string"
               },
               {
@@ -556,7 +556,7 @@ export type TokenDispenser =
                 }
               },
               {
-                "name": "recovery_id",
+                "name": "recoveryId",
                 "type": "u8"
               },
               {
@@ -587,7 +587,7 @@ export type TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -1147,7 +1147,7 @@ export const IDL: TokenDispenser =
                 "type": "string"
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -1165,7 +1165,7 @@ export const IDL: TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -1186,7 +1186,7 @@ export const IDL: TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -1204,7 +1204,7 @@ export const IDL: TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]
@@ -1213,7 +1213,7 @@ export const IDL: TokenDispenser =
             "name": "Cosmwasm",
             "fields": [
               {
-                "name": "chain_id",
+                "name": "chainId",
                 "type": "string"
               },
               {
@@ -1226,7 +1226,7 @@ export const IDL: TokenDispenser =
                 }
               },
               {
-                "name": "recovery_id",
+                "name": "recoveryId",
                 "type": "u8"
               },
               {
@@ -1257,7 +1257,7 @@ export const IDL: TokenDispenser =
                 }
               },
               {
-                "name": "verification_instruction_index",
+                "name": "verificationInstructionIndex",
                 "type": "u8"
               }
             ]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,7 +43,7 @@
         "wagmi": "^1.4.7"
       },
       "devDependencies": {
-        "@coral-xyz/spl-token": "^0.27.0",
+        "@coral-xyz/spl-token": "^0.29.0",
         "@next/bundle-analyzer": "^14.0.1",
         "@tailwindcss/typography": "^0.5.2",
         "@types/bn.js": "^5.1.1",
@@ -2499,15 +2499,86 @@
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
-    "node_modules/@coral-xyz/spl-token": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/spl-token/-/spl-token-0.27.0.tgz",
-      "integrity": "sha512-9NPJLhi63KwBZ/Y5A42AdRWd8ecKx10U338SysoZmaWIdPmOItCu444c8YWBZt7R7Lhs3bN4+OqI5DvMunGJHA==",
+    "node_modules/@coral-xyz/borsh": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
+      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
       "dev": true,
       "dependencies": {
-        "@coral-xyz/anchor": "=0.27.0",
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
+      }
+    },
+    "node_modules/@coral-xyz/spl-token": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/spl-token/-/spl-token-0.29.0.tgz",
+      "integrity": "sha512-NgkbBGI87pUPmf0FNuPoizwQImKLVt1hc28ylxTvszbRg19azqeLs1hBK7WGHV2RXDN+RqH8dASb+7Gj1aXJMw==",
+      "dev": true,
+      "dependencies": {
+        "@coral-xyz/anchor": "=0.29.0",
         "@native-to-anchor/buffer-layout": "=0.1.0"
       }
+    },
+    "node_modules/@coral-xyz/spl-token/node_modules/@coral-xyz/anchor": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
+      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
+      "dev": true,
+      "dependencies": {
+        "@coral-xyz/borsh": "^0.29.0",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.68.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@coral-xyz/spl-token/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@coral-xyz/spl-token/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@coral-xyz/spl-token/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "dev": true
     },
     "node_modules/@cosmjs/amino": {
       "version": "0.31.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "wagmi": "^1.4.7"
   },
   "devDependencies": {
-    "@coral-xyz/spl-token": "^0.27.0",
+    "@coral-xyz/spl-token": "^0.29.0",
     "@next/bundle-analyzer": "^14.0.1",
     "@tailwindcss/typography": "^0.5.2",
     "@types/bn.js": "^5.1.1",


### PR DESCRIPTION
* bump Solana version to 1.18.6 (this is a testnet release! I couldn't get things to work with the latest "stable" release because it simply won't built - the jokes truly write themselves)
* bump Anchor version to 0.29
* pull in pythnet_sdk merkle tree and related code and make it compatible with the above versions