### PR TITLE
#33 - normalize aptos address to 32 bytes

### DIFF
--- a/frontend/hooks/useAddress.tsx
+++ b/frontend/hooks/useAddress.tsx
@@ -13,7 +13,7 @@ export function useAptosAddress(): string | undefined {
   if (account && account.address) {
     return `${PREFIX_0X}${account.address
       .replace(PREFIX_0X, '')
-      .padStart(32, '0')}`
+      .padStart(64, '0')}`
   }
 }
 


### PR DESCRIPTION
<img width="582" alt="image" src="https://github.com/wormhole-foundation/example-grant-program/assets/1277510/dff387c4-7609-418d-bf54-c4ce0f463063">

64 since it is hex encoded, and each char is 4 bites so, 2 chars are 8 bits, 1 byte