### PR TITLE
Add Phantom Wallet support for EVM

### DIFF
--- a/frontend/components/wallets/EVM.tsx
+++ b/frontend/components/wallets/EVM.tsx
@@ -18,11 +18,13 @@ import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 import { InjectedConnector } from 'wagmi/connectors/injected'
+import { PhantomConnector } from './phantomConnector'
 
 import coinbase from '@images/coinbase.svg'
 import walletConnect from '@images/wallet-connect.svg'
 import metamask from '@images/metamask.svg'
 import okx from '@images/okx.svg'
+import phantom from '@images/phantom.svg'
 
 import { getInjectiveAddress } from '../../utils/getInjectiveAddress'
 
@@ -54,12 +56,23 @@ const config = createConfig({
         showQrModal: true,
       },
     }),
+    new PhantomConnector({
+      chains,
+      options: {
+        name: 'Phantom',
+      },
+    }),
   ],
   publicClient,
   webSocketPublicClient,
 })
 
-type WalletIds = 'metaMask' | 'coinbaseWallet' | 'walletConnect' | 'injected'
+type WalletIds =
+  | 'metaMask'
+  | 'coinbaseWallet'
+  | 'walletConnect'
+  | 'injected'
+  | 'phantom'
 
 type EVMWalletProviderProps = {
   children: ReactNode
@@ -153,6 +166,7 @@ function getIcon(id: WalletIds | undefined) {
   if (id === undefined) return undefined
   if (id === 'metaMask') return metamask
   if (id === 'coinbaseWallet') return coinbase
+  if (id === 'phantom') return phantom
   if (id === 'injected') return okx
   return walletConnect
 }

--- a/frontend/components/wallets/Solana.tsx
+++ b/frontend/components/wallets/Solana.tsx
@@ -58,7 +58,20 @@ export function SolanaWalletProvider({
 
   return (
     <ConnectionProvider endpoint={endpoint}>
-      <WalletProvider wallets={wallets} autoConnect>
+      <WalletProvider
+        onError={(e) => {
+          if (
+            e?.error?.code === -32603 &&
+            e?.error?.message === 'Unexpected error'
+          ) {
+            alert(
+              `An unexpected error happened.\n\nMake sure that the wallet that you selected it's connected to your Solana account and reload the page.`
+            )
+          }
+        }}
+        wallets={wallets}
+        autoConnect
+      >
         {children}
       </WalletProvider>
     </ConnectionProvider>

--- a/frontend/components/wallets/phantomConnector.ts
+++ b/frontend/components/wallets/phantomConnector.ts
@@ -1,0 +1,140 @@
+import { InjectedConnector } from 'wagmi/connectors/injected'
+import { WindowProvider, ConnectorNotFoundError } from 'wagmi'
+import {
+  ProviderRpcError,
+  ResourceNotFoundRpcError,
+  UserRejectedRequestError,
+  getAddress,
+} from 'viem'
+import type { Address } from 'abitype'
+import type { Chain } from '@wagmi/core/chains'
+
+type InjectedConnectorOptions = {
+  /** Name of connector */
+  name?: string | ((detectedName: string | string[]) => string)
+  /**
+   * [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Ethereum Provider to target
+   *
+   * @default
+   * () => typeof window !== 'undefined' ? window.ethereum : undefined
+   */
+  getProvider?: () => WindowProvider | undefined
+  /**
+   * MetaMask and other injected providers do not support programmatic disconnect.
+   * This flag simulates the disconnect behavior by keeping track of connection status in storage. See [GitHub issue](https://github.com/MetaMask/metamask-extension/issues/10353) for more info.
+   * @default true
+   */
+  shimDisconnect?: boolean
+}
+
+declare global {
+  interface Window {
+    phantom: {
+      ethereum: WindowProvider
+    }
+  }
+}
+
+export class PhantomConnector extends InjectedConnector {
+  readonly id = 'phantom'
+
+  protected shimDisconnectKey = `${this.id}.shimDisconnect`
+
+  constructor({
+    chains,
+    options: options_,
+  }: {
+    chains?: Chain[]
+    options?: InjectedConnectorOptions
+  } = {}) {
+    const options = {
+      name: 'Phantom',
+      shimDisconnect: true,
+      getProvider() {
+        function getReady(ethereum?: WindowProvider) {
+          const isPhantom = !!ethereum?.isPhantom
+          if (!isPhantom) return
+          return ethereum
+        }
+
+        if (typeof window === 'undefined') return
+        const ethereum = window?.phantom?.ethereum as WindowProvider | undefined
+        if (ethereum?.providers) return ethereum.providers.find(getReady)
+        return getReady(ethereum)
+      },
+      ...options_,
+    }
+    super({ chains, options })
+  }
+
+  async connect({ chainId }: { chainId?: number } = {}) {
+    try {
+      const provider = await this.getProvider()
+      if (!provider) throw new ConnectorNotFoundError()
+
+      if (provider.on) {
+        provider.on('accountsChanged', this.onAccountsChanged)
+        provider.on('chainChanged', this.onChainChanged)
+        provider.on('disconnect', this.onDisconnect)
+      }
+
+      this.emit('message', { type: 'connecting' })
+
+      // Attempt to show wallet select prompt with `wallet_requestPermissions` when
+      // `shimDisconnect` is active and account is in disconnected state (flag in storage)
+      let account: Address | null = null
+      if (
+        this.options?.shimDisconnect &&
+        !this.storage?.getItem(this.shimDisconnectKey)
+      ) {
+        account = await this.getAccount().catch(() => null)
+        const isConnected = !!account
+        if (isConnected)
+          // Attempt to show another prompt for selecting wallet if already connected
+          try {
+            await provider.request({
+              method: 'wallet_requestPermissions',
+              params: [{ eth_accounts: {} }],
+            })
+            // User may have selected a different account so we will need to revalidate here.
+            account = await this.getAccount()
+          } catch (error) {
+            if (this.isUserRejectedRequestError(error))
+              throw new UserRejectedRequestError(error as Error)
+            if (
+              (error as ProviderRpcError).code ===
+              new ResourceNotFoundRpcError(error as ProviderRpcError).code
+            )
+              throw error
+          }
+      }
+
+      if (!account) {
+        const accounts = await provider.request({
+          method: 'eth_requestAccounts',
+        })
+        account = getAddress(accounts[0] as string)
+      }
+
+      // Switch to chain if provided
+      let id = await this.getChainId()
+      let unsupported = this.isChainUnsupported(id)
+      if (chainId && id !== chainId) {
+        const chain = await this.switchChain(chainId)
+        id = chain.id
+        unsupported = this.isChainUnsupported(id)
+      }
+
+      if (this.options?.shimDisconnect)
+        this.storage?.setItem(this.shimDisconnectKey, true)
+
+      return { account, chain: { id, unsupported }, provider }
+    } catch (error) {
+      if (this.isUserRejectedRequestError(error))
+        throw new UserRejectedRequestError(error as Error)
+      if ((error as ProviderRpcError).code === -32002)
+        throw new ResourceNotFoundRpcError(error as ProviderRpcError)
+      throw error
+    }
+  }
+}

--- a/frontend/images/phantom.svg
+++ b/frontend/images/phantom.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="svg1"
+   width="400"
+   height="400"
+   viewBox="0 0 400 400"
+   sodipodi:docname="phantom.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.1909485"
+     inkscape:cx="179.68872"
+     inkscape:cy="253.5794"
+     inkscape:window-width="3008"
+     inkscape:window-height="1639"
+     inkscape:window-x="1440"
+     inkscape:window-y="893"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1" />
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Image"
+     id="g1">
+    <ellipse
+       style="fill:#ab9ff2;fill-opacity:1;stroke:#ab9ff2;stroke-opacity:1"
+       id="path10"
+       cx="201.04655"
+       cy="201.24156"
+       rx="191.29648"
+       ry="189.15146" />
+    <image
+       width="400"
+       height="400"
+       preserveAspectRatio="none"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAMAAAC3Ycb+AAAAaVBMVEWrn/K1q/PAt/PLw/TQyPTV&#10;zvXf2fbl3/fq5ffv6/f18ff69/f//fjFvfSwpfO7sfPa0/Xf2fXLwvT69/jl3/bFvPSwpfLa1PXA&#10;tvPl3/XQyPXf2vXf2vba1PbFvfO7sPPl4PfFvPPl4PZYBT37AAAKlElEQVR4nO3da2PaOgyAYZIC&#10;DQmDlt52unbr9v9/5CmXUiCOcRLHlqP3+cwGtbBlKU6YTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKBUlt9MZ/PbYlGW1XKvLBdFMZ9Nf+Sr2J9Ok+zHdH5b&#10;Lu2q4nZKWAa3vrkrqiuhOLW432SxP/NYrfJ2sTgq738wUzz7DMaiSyyObjfExJv1tNvMOFfd57H/&#10;kFHI765lb3cl06SfVT73MDXOQnJPiu8sv/McjT1C0kk+GyQaWw+z2H9cclbTYqho7JSb2H9hUgZa&#10;qs48sm45GnpyHLFuuVgNlzlqCibJNfl9sGhslU+x/2DZ8kBr1QmWrWYRwvHp8Tn23y1UnHB8Kkkk&#10;BtHCQURMYoaDiNREDgcROZdFD8eSiHxbvcSOxR4R2QlZlV9Rsvv9TB7+LgT2V8QejehEJI8Td7EH&#10;JC5Bq9UX1VdIRK1WBw96E7u01epgEXtcYpmKW60OdLZ+hU6PnZ+xBycCsdNjS9+iJXl6bGlbtERP&#10;jy1dOy3p02PrPvYgBSR+euyoyeur/2IPtRstPS2JpbmZjiki5LKHCw1TJIVs/m38U+QpiWx+NPop&#10;ktBytbeOPWKDSmu52nmJPWZDSmd39e1hxNfXp7EHt5PX2MM2lNWv2EPbzVjTepbgcrU3zhZjntZu&#10;99Qou/Bppo+9MvbgDSC56uPM6Kr1VXrVx5mxrVnppvODke2z1qnHY7kcVW24SXd7dTSmc6Wz2IPp&#10;w1vsUfRnFPEY0cY30W5JzUiK9dS3u9/GkURW/Z4bKskoLooEKz+q+XSdZVk+fXR6efH++/PV69/v&#10;LT7fGI75hopHNft+smg2u/qmxcmzYd3viX+IMICehYrHy/mDXjP7LCkvHtW7cf2UyWf1UPGoX86z&#10;bbQXtXF1/ZypZ/V1oPLcNE7NESkNj012jEjiWT1UPMxt2KZVy/yAhj9OnzXtWj1UPBoK6OeGt29Y&#10;dl57vFUaQsWjMdNujK9u/JK7LFopb7OCxaN5GTFuZxs3Sj9d3izdbVaweFgOeZqu4H80f2SXT5zs&#10;idJw8bBUz6Ys8rf55S4t6VT3veHiYT1RaFizLK92WbMSPb8Y8vK57fdx6muW9bq4w7cozYMOQY8z&#10;2D7Iut2AOnQlkyxEgsbD2oB9rr3ckkKcjo2lGJCwx30+rJ+l9lGsuyRz4XImwaNAq7DHfexf2dq1&#10;MWsd8ff62yV4RSTw9UF7lq1ts6yvzq+/XXq9k9DnGQiIXfDzPoEDklozK/z5K/sVilpArDnEISD2&#10;iIoT4fYPe1KvbTCsAXHYZaUVkHodNjz7tqf2cmsd4jK/vQ7YwLIY56mti3r9G2LtRbmcH/I7ZIOK&#10;dP+HbRGqFxbWFc5lx+550AYU64Ci7Ttf/3k324TKXN7O97ANJ9b9g7ZmhmHOWm4UdMnp6QQk3g0H&#10;zfc1mbaxlm2yywHGZOqQiPc7N5eGph+kbH5midOKlUqlHmWDddA4xOYRboyf0++JJhKQuDfYNv3I&#10;h3kX2/QUXrciKpH2e+Q7QMyJumkVNY+p41WDNAIS+w5C4+HQ5pRgXLQcN4kfw46kH/EfYGKIiG0V&#10;NUTE9TuVwiVcp93JwGoRsT916DIi7s/wSuDUiZAnZpyN1NVfQjwPYItHDiYQEClPCy/vvw4w5HcO&#10;m/Bic7hLZHXT5iZh+ScXYyf0U1Uxn88XziXR4nY+v205v23H8kSIcQkkJumHrYUkkHCkPxBISgIJ&#10;RXpvUVICCUL4OTkJFUhYH7GH3CrwoVEJZN8W7dSvHhfR9+s4XfEcGclliLod75bkXe9onkrWguRd&#10;b/yeewSCL0/p2/FuCd5kaUwgknu96kr0PbGbLJ0LluBjizoXLLmdLJU7rKXcnB7zmGJUUnO6wh7W&#10;ntDLhRp7WDtC63SVPaydj9hDb5b2D3v1IbP3rrUEWUotC9UuWEJTiNqMLjSF6M3oQqsQvRldZhWi&#10;OKPLvLtQbY2+lHmrjuKMLnPTqziji9z0qp4gH7FH30DzBJG46VV6Hf1A3u9UaK4JRZ7I0j1B5K1Y&#10;mmvCpcQVS3NNKHHFUj5B5K1YuidI81PPYlE+QeT1sXRPEHl9LOUTRF7nXXcNIvARQKqLdIFFiOo2&#10;r8RGr/IJYv1FhRiUTxB5KV3jDdAnxFXp2p5RdklcSldeFIqr0pUXhfImiPKULm6CaN/zimtjufy2&#10;34jJuzKlPKWLmyDKU7q8CaI8pYsrCmP/VEtk8p6loXzFEpdBVN8xJTGDKC9CxBXpyosQeUW68iJE&#10;3gTRvWIJfDqW6ishxt/ii0z1HkteTai7KpR3JV15VShwwVLdxxK45W36tWUVJGb0yUTrw0eXMjO6&#10;5jJd5IKl9nHJUhcsxQcWRS5YilOIzAVLb99E6IKlN4UIjYfaKkTe/WsHShtZ/2KPe5Pn2CMTh9QE&#10;ErosLH1v6TpeWqvExiNwTvd95aXr/yfzefs7QS9OvXi+eF/+7fbvxCb0Sdg6vVx5XrE23eb3r9iD&#10;bhOyTs89J6y3bnt2eQdHT4TcZM08P7rjc6fUZX7L3WBtBWyclL7Xx7zT+SXZ8Zh0zIpdZJ7Xx21m&#10;bv8fCo9HwF3vzPN03B0Xaf+vhMcj3AOZtr1un9NxP7Ld/pVkbx7H6OpI+Iz+0+7jt8wh8uMRrAzZ&#10;/WyNx+gfSrt2ndEE4hEqIDPPb/Z1QLpViItVvHF2Fubc+6HX7S0gx9KuzZ5E4Cl3gyAB+VoqfL3Z&#10;99Lz0/0fCe4nngrROTn2uj0F5DQVuH7+UuJvr5n4GSK743fTT0DOrmU4btz+pZA+drwMkd13r9tL&#10;QKqz7/qzyxSpElmutnwMkd3JxWsfAaku1p5Xh0+QzPSYBAhIeTIaHnZZl/G4fmpmIe+pADb9h8ju&#10;rBbrXxjW4zF5thaHpdDjoo16D1GbAex9udgQj8+INMe5SC0cg9ch5wPS91atptbHxvhXVLdpLVZ7&#10;wwbk4jBBz5sZLa2oWkiq+U1KqfzboOcWa4c7epWh9lbUevpY7KJSlY/vN6mUgXVDnuytH7bpk0TS&#10;aEX1NuD1EMNhmxatpwsp1Xa9DHfF0Hj4qeualUwrqrfB7lE3H0brGP+kau1+hjoG1HA40Kn1dEnN&#10;crU10EG5xsOaDq2nS0UCF149GmTfazk827afpWp6bA1x+t22Q83aLVpverLHwQBZ3X7Y/0+L/6lI&#10;sfnRk/8kcu3mC+evQKkwHBPvB4Gq6w3WP04NtEV6nVo/PN8i4FLBZdcjonGxOvC6Zi0ct6iv1pBU&#10;73rDMfG6Zr0474myWVNIqrnqaEz6dPwuh7JdybB5rO2Aq2KmPRpbnmrDDg3AfPpeLMpqWZVlMU/5&#10;KoZffqaI+3KFa3wcz3mK/UeMSZvi2UxZA3BwHXqwTI9B9Vq0yB7+PXc/DqS4ph6SQzfDSGkDMIBO&#10;EUnu5GxKstZ5JMGTs2lp1/cldwwvc26iVDN2VkGYz5FfRkN3dzyw/M1+CqEkGsH9fjMvXVXxnugZ&#10;//Stto3x4vBQ17IsHt+nv2lXAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAwNn/jO8UpthbSPoAAAAASUVORK5CYII=&#10;"
+       id="image1"
+       style="display:none" />
+    <g
+       id="g5"
+       transform="translate(34.320263,-7.8000598)"
+       style="fill:#ffffff">
+      <path
+         style="fill:#ffffff;stroke:#000000;stroke-opacity:0"
+         d="m 123.63096,159.90123 c 0,0 134.55104,214.50166 174.72135,69.42054 C 338.52262,84.240651 225.03175,92.820717 225.03175,92.820717 82.680647,111.54086 31.980246,255.84197 31.980246,255.84197 c 0,0 -33.9302613,109.98085 67.080521,60.06047 101.010783,-49.92039 -26.9102,-125.58097 -26.9102,-125.58097"
+         id="path2" />
+      <path
+         style="fill:#ffffff;stroke:#000000;stroke-opacity:0"
+         d="m 134.94105,277.68215 c 0,0 -11.31009,78.3906 80.73062,-3.12003 92.04071,-81.51063 -80.73062,3.12003 -80.73062,3.12003 z"
+         id="path3" />
+      <path
+         style="fill:#ffffff;stroke:#000000;stroke-opacity:0"
+         d="m 274.95213,270.66209 c 0,0 -50.70039,60.84047 -57.33044,4.29003 -6.63005,-56.55044 29.64023,-54.60042 29.64023,-54.60042"
+         id="path4" />
+      <path
+         style="fill:#ffffff;stroke:#000000;stroke-opacity:0"
+         d="m 145.47113,309.27239 c 0,0 35.88028,21.45016 71.37055,-33.93027 35.49028,-55.38042 -85.80066,-133.38103 -85.80066,-133.38103 l -35.880283,24.57019 -29.250231,28.08022 45.240364,79.17061 46.80036,12.4801"
+         id="path5" />
+    </g>
+    <ellipse
+       style="fill:#ab9ff2;fill-opacity:1;stroke:#ab9ff2;stroke-opacity:1"
+       id="path9"
+       cx="249.60193"
+       cy="146.83614"
+       rx="15.600121"
+       ry="19.695152" />
+    <ellipse
+       style="fill:#ab9ff2;fill-opacity:1;stroke:#ab9ff2;stroke-opacity:1"
+       id="path9-6"
+       cx="295.7218"
+       cy="146.1757"
+       rx="15.600121"
+       ry="19.695152" />
+  </g>
+</svg>


### PR DESCRIPTION
### Description

This PR adds support for Phantom Wallet in the EVM wallets selector.

If you were connected to an EVM address in Phantom, pressing it on the Solana wallets selector was doing nothing; this PR adds an alert for the user to know that he has to switch its Phantom account.

**Important:** Users CANNOT connect to evm AND solana at the same time with Phantom. They can use it as an EVM wallet OR as a Solana wallet, not both.

### Recording claiming with Phantom as EVM

https://github.com/wormhole-foundation/example-grant-program/assets/41705567/ef45fc7c-8551-4e3b-87bb-64b85e39edf6

